### PR TITLE
Add detection of *.md files with proper subtype

### DIFF
--- a/ftdetect/liquid.vim
+++ b/ftdetect/liquid.vim
@@ -2,3 +2,9 @@ autocmd BufNewFile,BufRead *.liquid set ft=liquid
 autocmd BufNewFile,BufRead */_layouts/*.html set ft=liquid
 autocmd BufNewFile,BufRead *.html,*.xml,*.markdown,*.textile
       \ if getline(1) == '---' | set ft=liquid | endif
+
+autocmd BufNewFile,BufRead *.md
+      \ if getline(1) == '---' |
+      \   let b:liquid_subtype = 'markdown' |
+      \   set ft=liquid |
+      \ endif


### PR DESCRIPTION
Added the the code from the [previous comment](https://github.com/tpope/vim-liquid/pull/2#issuecomment-5165959), which highlights properly in *.md files.

See #2.
