### PR TITLE
Add support for Jekyll's _includes directory

### DIFF
--- a/ftdetect/liquid.vim
+++ b/ftdetect/liquid.vim
@@ -2,5 +2,6 @@
 au BufNewFile,BufRead *.liquid			set ft=liquid
 
 au BufNewFile,BufRead */_layouts/*.html		set ft=liquid
+au BufNewFile,BufRead */_includes/*.html		set ft=liquid
 au BufNewFile,BufRead *.html,*.xml,*.markdown,*.textile
       \ if getline(1) == '---' | set ft=liquid | endif


### PR DESCRIPTION
Much like d6ae02c3, adds a detect for Jekyll's `_includes` directory.
