### PR TITLE
Add support for CSS and JS liquid files

### DIFF
--- a/ftdetect/liquid.vim
+++ b/ftdetect/liquid.vim
@@ -1,5 +1,8 @@
 " Liquid
 au BufNewFile,BufRead *.liquid					set ft=liquid
+au BufNewFile,BufRead *.scss.liquid					set ft=scss
+au BufNewFile,BufRead *.css.liquid					set ft=css
+au BufNewFile,BufRead *.js.liquid					set ft=javascript
 
 au BufNewFile,BufRead */_layouts/*.html,*/_includes/*.html	set ft=liquid
 au BufNewFile,BufRead *.html,*.xml,*.textile


### PR DESCRIPTION
I’ve been using Vim (and vim-liquid) recently to edit Shopify theme files and I noticed that the `*.css.liquid`, `*.scss.liquid` and `*.js.liquid` files Shopify uses were being detected as Liquid files when really, they’re just normal CSS, SCSS and JavaScript files with a few Liquid tags in them.

I therefore suggest that we treat them as normal files so other plugins/settings can continue to work with them.
