### PR TITLE
Set subtype for Shopify alternate templates

### DIFF
--- a/ftdetect/liquid.vim
+++ b/ftdetect/liquid.vim
@@ -9,3 +9,8 @@ au BufNewFile,BufRead *.markdown,*.mkd,*.mkdn,*.md
       \   let b:liquid_subtype = 'markdown' |
       \   set ft=liquid |
       \ endif
+
+" Set subtype for Shopify alternate templates
+au BufNewFile,BufRead */templates/**.liquid,*/layout/**.liquid,*/snippets/**.liquid
+      \ let b:liquid_subtype = 'html' |
+      \ set ft=liquid |


### PR DESCRIPTION
Shopify allows to create [alternative templates](http://docs.shopify.com/themes/theme-templates/alternate-templates) by specifying an additional custom extension:

> An alternate product template will contain the word 'product' in it. It will be called something like `product.shirts.liquid`

But the HTML code in these templates would not be highlighted in Vim, only Liquid tags. I suggest to set the `html` subtype for Liquid files in the Shopify template folders.
